### PR TITLE
Remove deprecated libavresample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository  = "https://github.com/bacek/rust-ffmpeg4"
 keywords    = ["audio", "video"]
 
 [features]
-default = ["codec", "device", "filter", "format", "resampling", "software-resampling", "software-scaling"]
+default = ["codec", "device", "filter", "format", "resampling", "software-scaling"]
 
 static = ["ffmpeg4-sys/static"]
 build  = ["static", "ffmpeg4-sys/build"]
@@ -84,9 +84,8 @@ codec               = ["ffmpeg4-sys/avcodec"]
 device              = ["ffmpeg4-sys/avdevice", "format"]
 filter              = ["ffmpeg4-sys/avfilter"]
 format              = ["ffmpeg4-sys/avformat", "codec"]
-resampling          = ["ffmpeg4-sys/avresample"]
+resampling          = ["ffmpeg4-sys/swresample"]
 postprocessing      = ["ffmpeg4-sys/postproc"]
-software-resampling = ["ffmpeg4-sys/swresample"]
 software-scaling    = ["ffmpeg4-sys/swscale", "codec"]
 
 [dependencies]


### PR DESCRIPTION
This is mostly a draft PR, but: `avresample` has been deprecated for quite some time now (see https://www.ffmpeg.org/doxygen/trunk/avresample_8h.html), and libswresample replaces it.

Not sure how this works on your systems, but this is the only way I managed to build `rust-ffmpeg4` on Arch (since `avresample`) has been removed from the official `ffmpeg` package (default behavior when you compile ffmpeg)

What do you think? :)