### PR TITLE
Fix software-resampling module name

### DIFF
--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -32,10 +32,10 @@ pub fn converter(
     )
 }
 
-#[cfg(feature = "software-resampling")]
+#[cfg(feature = "resampling")]
 pub mod resampling;
 
-#[cfg(feature = "software-resampling")]
+#[cfg(feature = "resampling")]
 #[inline]
 pub fn resampler(
     (in_format, in_layout, in_rate): (::format::Sample, ::ChannelLayout, u32),


### PR DESCRIPTION
I forgot to change the feature name accordingly to the removal of `avresample`, and my code using `ffmpeg::software::resampling::context::Context::get` didn't want to compile; this fixes it (since the `software-resampling` feature has been merged with `resampling`.

I've checked in the rest of the code, there's no other mention of `avresample`, so that should hopefully do it