### PR TITLE
Fix flush resampling context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ before_install:
 
 script: |
     travis_wait cargo build --verbose --features "build"
+    travis_wait cargo build --examples --verbose --features="build"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ version  = "0.22"
 optional = true
 
 [dependencies.ffmpeg4-sys]
-version = "4.2"
-default-features = false
-# Temporary change it
+version = "4.2.2"
 git = "https://github.com/bacek/rust-ffmpeg4-sys"
+branch = "release/4.2"
+default-features = false

--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -112,16 +112,10 @@ impl Context {
         output: &mut frame::Audio,
     ) -> Result<Option<Delay>, Error> {
         output.set_rate(self.output.rate);
+        output.set_format(self.output.format);
+        output.set_channel_layout(self.output.channel_layout);
 
         unsafe {
-            if output.is_empty() {
-                output.alloc(
-                    self.output.format,
-                    input.samples(),
-                    self.output.channel_layout,
-                );
-            }
-
             match swr_convert_frame(self.as_mut_ptr(), output.as_mut_ptr(), input.as_ptr()) {
                 0 => Ok(self.delay()),
 
@@ -135,6 +129,8 @@ impl Context {
     /// When there are no more internal frames `Ok(None)` will be returned.
     pub fn flush(&mut self, output: &mut frame::Audio) -> Result<Option<Delay>, Error> {
         output.set_rate(self.output.rate);
+        output.set_format(self.output.format);
+        output.set_channel_layout(self.output.channel_layout);
 
         unsafe {
             match swr_convert_frame(self.as_mut_ptr(), output.as_mut_ptr(), ptr::null()) {


### PR DESCRIPTION
Changed two things:
* I saw `rust-ffmpeg4-sys` version was bumped, so I guess no need for github now (it's failing anyways :smile: )
* More important change: I've removed the `alloc()` in the context resampling, since `swr_convert_frame` allocates stuff itself here https://ffmpeg.org/doxygen/trunk/swresample__frame_8c_source.html more precisely, calculating itself the number of frame needed. Also fixed the `flush()`

Hope it makes sense :smile: 